### PR TITLE
Build fig array using frombuffer

### DIFF
--- a/tfplot/figure.py
+++ b/tfplot/figure.py
@@ -81,7 +81,7 @@ def to_array(fig):
     fig.canvas.draw()
     w, h = fig.canvas.get_width_height()
 
-    img = np.fromstring(fig.canvas.tostring_argb(), dtype=np.uint8, sep='')
+    img = np.frombuffer(fig.canvas.tostring_argb(), dtype=np.uint8)
     img = img.reshape((h, w, 4))
     img = img[:, :, (1, 2, 3, 0)]   # argb -> rgba
     return img


### PR DESCRIPTION
`fig.canvas.tostring_argb()` returns bytes, not a str.
`np.fromstring()` has been deprecated on bytes inputs since
numpy v1.14.

DeprecationWarning: The binary mode of fromstring is deprecated, as it
behaves surprisingly on unicode inputs. Use frombuffer instead

https://github.com/numpy/numpy/blob/82428bb72589c6fd781689feb1f501a6a29c6fdc/numpy/core/src/multiarray/multiarraymodule.c#L2036

Resolves #9.