### PR TITLE
Fix summary wrapper when plotting is not batched

### DIFF
--- a/tfplot/summary.py
+++ b/tfplot/summary.py
@@ -148,6 +148,8 @@ def wrap(plot_func, _sentinel=None,
             raise TypeError("summary_name should be a string")
 
         plot_op = factory_fn(*args, **kwargs_call)
+        if not batch:
+            plot_op = tf.expand_dims(plot_op, axis=0)
         return tf.summary.image(summary_name, plot_op,
                                 max_outputs=kwargs_call.pop('max_outputs', 3),
                                 collections=kwargs_call.pop('collections', None),

--- a/tfplot/summary.py
+++ b/tfplot/summary.py
@@ -149,6 +149,7 @@ def wrap(plot_func, _sentinel=None,
 
         plot_op = factory_fn(*args, **kwargs_call)
         if not batch:
+            # add batch dimension expected by tf.summary.image
             plot_op = tf.expand_dims(plot_op, axis=0)
         return tf.summary.image(summary_name, plot_op,
                                 max_outputs=kwargs_call.pop('max_outputs', 3),

--- a/tfplot/summary_test.py
+++ b/tfplot/summary_test.py
@@ -74,7 +74,7 @@ class TestSummary(test_util.TestcaseBase):
         self.assertEquals(test_util.hash_image(png), 'dbb47a3281626678894084fa58066f69a2570df4')
 
 
-    def test_summary_wrap(self):
+    def test_summary_wrap_batch(self):
         '''tests tfplot.summary.wrap'''
 
         summary_heatmap = tfplot.summary.wrap(sns.heatmap, figsize=(2, 2), cmap='jet',
@@ -94,6 +94,24 @@ class TestSummary(test_util.TestcaseBase):
         if sys.platform == 'darwin':
             imgcat(s.value[0].image.encoded_image_string)
             imgcat(s.value[1].image.encoded_image_string)
+
+
+    def test_summary_wrap_nobatch(self):
+        '''tests tfplot.summary.wrap'''
+
+        summary_heatmap = tfplot.summary.wrap(sns.heatmap, figsize=(2, 2), cmap='jet',
+                                              batch=False)
+
+        summary_op = summary_heatmap("heatmap_1",
+                                     tf.constant(np.random.RandomState(42).normal(size=[4, 4])),
+                                     )
+        s = self._execute_summary_op(summary_op)
+
+        self.assertEquals(len(s.value), 1)
+        self.assertEquals(s.value[0].tag, ('heatmap_1/image/0'))
+
+        if sys.platform == 'darwin':
+            imgcat(s.value[0].image.encoded_image_string)
 
 
 


### PR DESCRIPTION
tf.summary.image expects a rank 4 image tensor with batch dimension
along the first axis. This means that tfplot.summary.wrap needs to add
an the extra batch dimension when tfplot.autowrap does not produce
batches of images.

This commit makes the following changes:
  - Add a test case to illustrate the issue with tfplot.summary.wrap
    when batch=False
  - Prepend an extra dimension to the images plotted when batch=False,
    to match the expected input of tf.summary.image